### PR TITLE
Fix methods::new to work with R version 3.4.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,6 @@ Description: An implementation in the R language of the Refinitiv API for the Ei
 Version: 0.1.0
 Author: Ahmed Mohamed Ali
 Maintainer: Ahmed Mohamed Ali <ahmed.mohamedali2016@gmail.com>
-Description: 
 License: Apache2
 Encoding: UTF-8
 LazyData: true

--- a/R/profile.R
+++ b/R/profile.R
@@ -14,7 +14,7 @@ init <- function()
 
   if (exists("requestInfo") == FALSE)
   {
-    requestInfo <<- new("RequestInfo")
+    requestInfo <<- methods::new("RequestInfo")
   }
 
 


### PR DESCRIPTION
Thanks for this nice package. The package was installing but not working in a machine with R version 3.4.4 (it was complaining that it could not find function `new`). With this change (using `methods::new` instead of only `new`), the package works always.