### PR TITLE
Auto-unbox request JSON in debug output

### DIFF
--- a/R/json_request.R
+++ b/R/json_request.R
@@ -20,7 +20,7 @@ send_json_request <- function(entity, request_data, debug=FALSE)
   if (debug)
   {
     print("Request *************************************")
-    print(jsonlite::toJSON(request))
+    print(jsonlite::toJSON(request, auto_unbox = TRUE))
     print("Response *************************************")
     print(response_data)
     print("Response status *************************************")


### PR DESCRIPTION
This commit makes the debug output for the request match the JSON actually submitted to the API, which is auto-unboxed by httr (see https://github.com/r-lib/httr/commit/e30854c0077da7bd9cfd25c957595fb2153c7f8d).